### PR TITLE
User/antsai/merged smart card

### DIFF
--- a/Samples/SmartCard/cs/Scenario7_ListAllCards.xaml.cs
+++ b/Samples/SmartCard/cs/Scenario7_ListAllCards.xaml.cs
@@ -21,7 +21,7 @@ namespace SDKTemplate
         {
             get { return Reader.Name; }
         }
-        public string CardName
+        public List<string> CardNames
         {
             get;
             set;
@@ -82,17 +82,19 @@ namespace SDKTemplate
                     // each (reader, card) pair.
                     IReadOnlyList<SmartCard> cards = await reader.FindAllCardsAsync();
 
+                    var item = new SmartCardListItem()
+                    {
+                        Reader = reader,
+                        CardNames = new List<string>(cards.Count),
+                    };
+
                     foreach (SmartCard card in cards)
                     {
                         SmartCardProvisioning provisioning = await SmartCardProvisioning.FromSmartCardAsync(card);
-
-                        SmartCardListItem item = new SmartCardListItem()
-                        {
-                            Reader = card.Reader,
-                            CardName = await provisioning.GetNameAsync()
-                        };
-                        cardItems.Add(item);
+                        item.CardNames.Add(await provisioning.GetNameAsync());
                     }
+
+                    cardItems.Add(item);
                 }
                 // Bind the source of ItemListView to our SmartCardListItem list.
                 ItemListView.ItemsSource = cardItems;

--- a/Samples/SmartCard/cs/Scenario7_ListAllCards.xaml.cs
+++ b/Samples/SmartCard/cs/Scenario7_ListAllCards.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Windows.Devices.Enumeration;
 using Windows.Devices.SmartCards;
@@ -7,28 +7,39 @@ using Windows.UI.Xaml.Controls;
 
 namespace SDKTemplate
 {
+
     public class SmartCardListItem
     {
-        public string ReaderName
+
+        public SmartCardReader Reader
         {
             get;
             set;
         }
 
+        public string ReaderName
+        {
+            get { return Reader.Name; }
+        }
         public string CardName
         {
             get;
             set;
         }
-
     }
     public sealed partial class Scenario7_ListAllCards : Page
     {
         MainPage rootPage = MainPage.Current;
+        List<SmartCardListItem> cardItems;
 
         public Scenario7_ListAllCards()
         {
             this.InitializeComponent();
+            // This list will be bound to our ItemListView once it has been
+            // filled with SmartCardListItems.  The SmartCardListItem class
+            // is defined above, and describes a reader/card pair with a
+            // reader name and a card name.
+            cardItems = new List<SmartCardListItem>();
         }
 
         /// <summary>
@@ -43,12 +54,7 @@ namespace SDKTemplate
             try
             {
                 rootPage.NotifyUser("Enumerating smart cards...", NotifyType.StatusMessage);
-
-                // This list will be bound to our ItemListView once it has been
-                // filled with SmartCardListItems.  The SmartCardListItem class
-                // is defined above, and describes a reader/card pair with a
-                // reader name and a card name.
-                List<SmartCardListItem> cardItems = new List<SmartCardListItem>();
+                cardItems.Clear();
 
                 // First we get the device selector for smart card readers using
                 // the static GetDeviceSelector method of the SmartCardReader
@@ -82,16 +88,16 @@ namespace SDKTemplate
 
                         SmartCardListItem item = new SmartCardListItem()
                         {
-                            ReaderName = card.Reader.Name,
+                            Reader = card.Reader,
                             CardName = await provisioning.GetNameAsync()
                         };
-
                         cardItems.Add(item);
                     }
                 }
-
                 // Bind the source of ItemListView to our SmartCardListItem list.
                 ItemListView.ItemsSource = cardItems;
+                ItemListView.SelectedIndex = -1;
+                ItemListView.SelectionChanged += SelectedIndexChange;
 
                 rootPage.NotifyUser("Enumerating smart cards completed.", NotifyType.StatusMessage);
             }
@@ -103,6 +109,11 @@ namespace SDKTemplate
             {
                 b.IsEnabled = true;
             }
+        }
+        void SelectedIndexChange(object sender, SelectionChangedEventArgs args)
+        {
+            rootPage.SmartCardReaderDeviceId = cardItems[ItemListView.SelectedIndex].Reader.DeviceId;
+            rootPage.NotifyUser("select card reader: " + rootPage.SmartCardReaderDeviceId , NotifyType.StatusMessage);
         }
     }
 }

--- a/Samples/SmartCard/cs/Scenario8_TransmitAPDU.xaml.cs
+++ b/Samples/SmartCard/cs/Scenario8_TransmitAPDU.xaml.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using System.Linq;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.Storage.Streams;
@@ -26,30 +27,35 @@ namespace SDKTemplate
             if (!rootPage.ValidateTPMSmartCard())
             {
                 rootPage.NotifyUser("Use Scenario One to create a TPM virtual smart card.", NotifyType.ErrorMessage);
-                return;
+            }
+            if (ApduToSend.Text.Length % 2 != 0)
+            {
+                rootPage.NotifyUser("Lenght of ApduToSend must be odd.", NotifyType.ErrorMessage);
             }
 
             Button b = sender as Button;
             b.IsEnabled = false;
 
             try
-            {
-                SmartCard card = await rootPage.GetSmartCard();
-
-                IBuffer result = null;
-
-                using (SmartCardConnection connection = await card.ConnectAsync())
+            {                
                 {
-                    // Read EF.ATR file
-                    // The command is meant specifically for GIDS cards 
-                    // (such as TPM VSCs), and will fail on other types.
-                    byte[] readEfAtrBytes = { 0x00, 0xCB, 0x2F, 0x01, 0x02, 0x5C, 0x00, 0xFF };
+                    SmartCard card = await rootPage.GetSmartCard();
+                    SmartCardProvisioning provisioning = await SmartCardProvisioning.FromSmartCardAsync(card);
+                    IBuffer result = null;
+                    using (SmartCardConnection connection = await card.ConnectAsync())
+                    {
+                        rootPage.NotifyUser(ApduToSend.Text , NotifyType.StatusMessage);
+                        byte[] sendapdu  = Enumerable.Range(0, ApduToSend.Text.Length).Where(x => x % 2 == 0).Select(x => Convert.ToByte(ApduToSend.Text.Substring(x, 2), 16)).ToArray();
+                        // default: get atr
+                        // 00 CB 2F 01 02 5C 00 FF
+                        // select ppse
+                        // 00 A4 04 00 0E 32 50 41 59 2E 53 59 53 2E 44 44 46 30 31 00 
 
-                    IBuffer readEfAtr = CryptographicBuffer.CreateFromByteArray(readEfAtrBytes);
+                        IBuffer apdu = CryptographicBuffer.CreateFromByteArray(sendapdu);
 
-                    result = await connection.TransmitAsync(readEfAtr);
-                
-                    rootPage.NotifyUser("Response: " + CryptographicBuffer.EncodeToHexString(result), NotifyType.StatusMessage);
+                        result = await connection.TransmitAsync(apdu);
+                        ApduResponse.Text = CryptographicBuffer.EncodeToHexString(result);
+                    }
                 }
             }
             catch (Exception ex)

--- a/Samples/SmartCard/shared/Scenario7_ListAllCards.xaml
+++ b/Samples/SmartCard/shared/Scenario7_ListAllCards.xaml
@@ -1,4 +1,4 @@
-﻿<!--
+<!--
 //*********************************************************
 //
 // Copyright (c) Microsoft. All rights reserved.
@@ -41,7 +41,7 @@
                     <ListView x:Name="ItemListView" Width="300" Height="Auto" 
                         HorizontalAlignment="Left" BorderBrush="LightGray" BorderThickness="1" 
                         VerticalAlignment="Stretch" ScrollViewer.VerticalScrollBarVisibility="Auto"
-                        ScrollViewer.HorizontalScrollBarVisibility="Auto" SelectionMode="None">
+                        ScrollViewer.HorizontalScrollBarVisibility="Auto" SelectionMode="Single">
                         <ListView.ItemTemplate>
                             <DataTemplate>
                                 <Grid HorizontalAlignment="Left">

--- a/Samples/SmartCard/shared/Scenario7_ListAllCards.xaml
+++ b/Samples/SmartCard/shared/Scenario7_ListAllCards.xaml
@@ -48,7 +48,7 @@
                                     <StackPanel Orientation="Horizontal" Margin="10,10,0,0">
                                         <StackPanel Margin="0,0,0,0" Orientation="Vertical">
                                             <TextBlock TextWrapping="Wrap" Width="300" VerticalAlignment="Center" Text="{Binding ReaderName}" HorizontalAlignment="Left" FontFamily="Segoe UI" />
-                                            <TextBlock TextWrapping="Wrap" Width="300" MaxHeight="20" VerticalAlignment="Center" Text="{Binding CardName}" HorizontalAlignment="Left" FontFamily="Segoe UI" FontSize="12"/>
+                                            <ListBox ItemsSource="{Binding CardNames}" Width="300" VerticalAlignment="Center" HorizontalAlignment="Left" FontFamily="Segoe UI" FontSize="12" IsHitTestVisible="False" />
                                         </StackPanel>
                                     </StackPanel>
                                 </Grid>

--- a/Samples/SmartCard/shared/Scenario8_TransmitAPDU.xaml
+++ b/Samples/SmartCard/shared/Scenario8_TransmitAPDU.xaml
@@ -1,4 +1,4 @@
-﻿<!--
+<!--
 //*********************************************************
 //
 // Copyright (c) Microsoft. All rights reserved.
@@ -32,11 +32,15 @@
                     Click Transmit APDU to connect to your smart card and transmit the APDU. The response will be displayed in the output box.
                     This APDU reads the smart card EF.ATR file.
                 </TextBlock>
+                <TextBlock Text="APDU:" Style="{StaticResource SampleHeaderTextStyle}"/>
+                <TextBox x:Name="ApduToSend" TextWrapping="Wrap" Text="00CB2F01025C00FF" />
+                <TextBlock Text="Response:" Style="{StaticResource SampleHeaderTextStyle}"/>
+                <TextBox x:Name="ApduResponse" Text="" />
             </StackPanel>
-
+            
             <ScrollViewer Grid.Row="1" VerticalScrollMode="Auto" VerticalScrollBarVisibility="Auto">
                 <StackPanel Orientation="Vertical" VerticalAlignment="Top">
-                    <Button x:Name="TransmitAPDU" Content="Transmit APDU" Margin="0,0,10,0" Click="Transmit_Click"/>
+                    <Button x:Name="TransmitAPDU" Content="Transmit APDU" Margin="0,0,50,0" Click="Transmit_Click"/>
                 </StackPanel>
             </ScrollViewer>
         </Grid>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Note that nontrivial changes will need to be reviewed by the feature team and will take time. -->

## Description
In the original code, it will only send getatr for the virtual smart card created in the scenario 1
1. Add a selected index and make it selectable to choose the card reader user would like to send apdu.
2. Add textbox for input apdu user want to send and response textbox to show the response

<!-- Describe your changes in detail -->
<!-- If this change fixes an open issue, please link to the issue here. -->

## Testing
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran. -->
can detect nfc smart card and send/receive apdu.

## Type of change
<!-- Select all that apply. -->
- [ ] Bug fix
- [V] New feature
- [ ] Porting to new language

## Supported platforms
Minimum OS version: (example: 18362)
18362

<!-- Select all that apply. -->
- [V] All UWP platforms
- [ ] Desktop
- [ ] Holographic
- [ ] IoT
- [ ] Xbox
- [ ] 10X

## Supported languages
<!-- Select all that apply. -->
<!-- If the sample is available in more than one language, make sure your change applies to all versions. -->
<!-- C++/CX, JavaScript, and Visual Basic samples are no longer being maintained. -->
<!-- They are archived when the underlying sample changes. C++/CX samples are ported to C++/WinRT. -->
- [V] C#
- [ ] C++/WinRT

## Additional remarks
<!-- Optional. -->
